### PR TITLE
Fix current URI used by Crawler in tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/InteractsWithPages.php
+++ b/src/Illuminate/Foundation/Testing/InteractsWithPages.php
@@ -64,7 +64,7 @@ trait InteractsWithPages
 
         $this->currentUri = $this->app->make('request')->fullUrl();
 
-        $this->crawler = new Crawler($this->response->getContent(), $uri);
+        $this->crawler = new Crawler($this->response->getContent(), $this->currentUri);
 
         return $this;
     }


### PR DESCRIPTION
I was making a wizard with POST forms and suddenly discovered that there is error in LTS 5.1. After submitting form, if we follow redirects URL usually will be different from `$uri` and submitting next form will fail.